### PR TITLE
BugFix - Places Response dispatch to all other listeners  + Fix Flaky functional test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
 # Workflows orchestrate a set of jobs to be run;
 workflows:
   version: 2
-  build-test-deploy:
+  build-test:
     jobs:
       - build-and-unit-test
       - functional-test

--- a/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/MonitorExtension.kt
+++ b/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/MonitorExtension.kt
@@ -1,3 +1,14 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
 package com.adobe.marketing.mobile.places
 
 import com.adobe.marketing.mobile.*

--- a/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/PlacesIntegrationTest.kt
+++ b/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/PlacesIntegrationTest.kt
@@ -1,3 +1,14 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
 package com.adobe.marketing.mobile.places
 
 import android.app.Application
@@ -227,8 +238,11 @@ class PlacesIntegrationTest {
             countDownLatch.countDown()
         }, {})
 
-        // verify
+        // wait
         Assert.assertTrue(countDownLatch.await(3, TimeUnit.SECONDS))
+        MonitorExtension.waitForSharedStateToSet.await(3,TimeUnit.SECONDS)
+
+        // verify
         assertEquals("poiName1", getCurrentPOIName())
         assertEquals("poiName1", getLastEnteredPOIName())
         assertNull(getLastExitedPOI())
@@ -240,7 +254,6 @@ class PlacesIntegrationTest {
         val configurationLatch = CountDownLatch(1)
         configurationAwareness { configurationLatch.countDown() }
         setupConfiguration(privacyStatus = MobilePrivacyStatus.OPT_OUT.value)
-
 
         // test
         Places.getNearbyPointsOfInterest(mockLocation(), 20,{}, { error ->
@@ -380,8 +393,11 @@ class PlacesIntegrationTest {
             countDownLatch.countDown()
         }, {})
 
+        // wait
         Assert.assertTrue(countDownLatch.await(3, TimeUnit.SECONDS))
         MonitorExtension.waitForSharedStateToSet.await(3, TimeUnit.SECONDS)
+
+        // verify
         assertEquals("Cityview Plaza", getCurrentPOIName())
         assertEquals("Cityview Plaza", getLastEnteredPOIName())
         assertNull(getLastExitedPOI())

--- a/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/PlacesIntegrationTest.kt
+++ b/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/PlacesIntegrationTest.kt
@@ -386,9 +386,20 @@ class PlacesIntegrationTest {
         assertEquals("Cityview Plaza", getLastEnteredPOIName())
         assertNull(getLastExitedPOI())
 
+        // reset
+        MonitorExtension.reset()
+
         // test
         Places.clear()
         countDownLatch = CountDownLatch(1)
+
+        // wait
+        MonitorExtension.waitForSharedStateToSet.await(3, TimeUnit.SECONDS)
+
+        // verify shared states are reset
+        assertNull(getCurrentPOIName())
+        assertNull(getLastEnteredPOIName())
+        assertNull(getLastExitedPOI())
 
         // verify last known location is reset
         Places.getLastKnownLocation { location ->
@@ -396,11 +407,8 @@ class PlacesIntegrationTest {
             countDownLatch.countDown()
         }
 
-        // verify shared states are reset
+        // wait and verify
         Assert.assertTrue(countDownLatch.await(3, TimeUnit.SECONDS))
-        assertNull(getCurrentPOIName())
-        assertNull(getLastEnteredPOIName())
-        assertNull(getLastExitedPOI())
     }
 
     //---------------------------------------------------------------------------------------------

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesDispatcher.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesDispatcher.java
@@ -37,7 +37,7 @@ class PlacesDispatcher {
         responseEventData.put(PlacesConstants.EventDataKeys.Places.NEAR_BY_PLACES_LIST, PlacesUtil.convertPOIListToMap(poiList));
         responseEventData.put(PlacesConstants.EventDataKeys.Places.RESULT_STATUS, resultStatus.getValue());
         if (event != null) {
-            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchNearbyPlaces - Dispatching nearby places response event for API callback with %d POIs", poiList.size());
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchNearbyPlaces - Dispatching nearby places response event for `getNearbyPointsOfInterest` API callback with %d POIs", poiList.size());
             final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETNEARBYPLACES, EventType.PLACES,
                     EventSource.RESPONSE_CONTENT)
                     .setEventData(responseEventData)
@@ -72,7 +72,7 @@ class PlacesDispatcher {
         final Map<String, Object> responseEventData = new HashMap<>();
         responseEventData.put(PlacesConstants.EventDataKeys.Places.USER_WITHIN_POIS, PlacesUtil.convertPOIListToMap(poiList));
         if (event != null) {
-            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchUserWithinPOIs - Dispatching user within POIs event API callback with %d POIs", poiList.size());
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchUserWithinPOIs - Dispatching user within POIs event for `getCurrentPointsOfInterest` API callback with %d POIs", poiList.size());
             final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETUSERWITHINPLACES, EventType.PLACES,
                     EventSource.RESPONSE_CONTENT)
                     .setEventData(responseEventData)
@@ -94,7 +94,7 @@ class PlacesDispatcher {
         responseEventData.put(PlacesConstants.EventDataKeys.Places.LAST_KNOWN_LATITUDE, latitude);
         responseEventData.put(PlacesConstants.EventDataKeys.Places.LAST_KNOWN_LONGITUDE, longitude);
         if (event != null) {
-            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchLastKnownLocation - Dispatching last known location event for API callback with latitude: %s and longitude: %s",
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchLastKnownLocation - Dispatching last known location event for `getLastKnownLocation` API callback with latitude: %s and longitude: %s",
                     latitude, longitude);
             final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETLASTKNOWNLOCATION, EventType.PLACES,
                     EventSource.RESPONSE_CONTENT)

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesDispatcher.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesDispatcher.java
@@ -36,20 +36,28 @@ class PlacesDispatcher {
         final Map<String, Object> responseEventData = new HashMap<>();
         responseEventData.put(PlacesConstants.EventDataKeys.Places.NEAR_BY_PLACES_LIST, PlacesUtil.convertPOIListToMap(poiList));
         responseEventData.put(PlacesConstants.EventDataKeys.Places.RESULT_STATUS, resultStatus.getValue());
-        Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchNearbyPlaces - Dispatching nearby places event with %d POIs", poiList.size());
-        final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETNEARBYPLACES, EventType.PLACES,
-                EventSource.RESPONSE_CONTENT)
-                .setEventData(responseEventData)
-                .inResponseToEvent(event)
-                .build();
-        extensionApi.dispatch(responseEvent);
+        if (event != null) {
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchNearbyPlaces - Dispatching nearby places response event for API callback with %d POIs", poiList.size());
+            final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETNEARBYPLACES, EventType.PLACES,
+                    EventSource.RESPONSE_CONTENT)
+                    .setEventData(responseEventData)
+                    .inResponseToEvent(event)
+                    .build();
+            extensionApi.dispatch(responseEvent);
+        } else {
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchNearbyPlaces - Dispatching nearby places response event for all other listeners with %d POIs", poiList.size());
+            final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETNEARBYPLACES, EventType.PLACES,
+                    EventSource.RESPONSE_CONTENT)
+                    .setEventData(responseEventData)
+                    .build();
+            extensionApi.dispatch(responseEvent);
+        }
     }
 
     void dispatchRegionEvent(final PlacesRegion region) {
         if (region == null) {
             return;
         }
-
         final Map<String, Object> regionData = region.getRegionEventData();
         final Event regionEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_PROCESSREGIONEVENT, EventType.PLACES,
                 EventSource.RESPONSE_CONTENT)
@@ -63,26 +71,46 @@ class PlacesDispatcher {
     void dispatchUserWithinPOIs(final List<PlacesPOI> poiList, final Event event) {
         final Map<String, Object> responseEventData = new HashMap<>();
         responseEventData.put(PlacesConstants.EventDataKeys.Places.USER_WITHIN_POIS, PlacesUtil.convertPOIListToMap(poiList));
-        Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchUserWithinPOIs - Dispatching user within POIs event with %d POIs", poiList.size());
-        final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETUSERWITHINPLACES, EventType.PLACES,
-                EventSource.RESPONSE_CONTENT)
-                .setEventData(responseEventData)
-                .inResponseToEvent(event)
-                .build();
-        extensionApi.dispatch(responseEvent);
+        if (event != null) {
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchUserWithinPOIs - Dispatching user within POIs event API callback with %d POIs", poiList.size());
+            final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETUSERWITHINPLACES, EventType.PLACES,
+                    EventSource.RESPONSE_CONTENT)
+                    .setEventData(responseEventData)
+                    .inResponseToEvent(event)
+                    .build();
+            extensionApi.dispatch(responseEvent);
+        } else {
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchUserWithinPOIs - Dispatching user within POIs event for other listeners with %d POIs", poiList.size());
+            final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETUSERWITHINPLACES, EventType.PLACES,
+                    EventSource.RESPONSE_CONTENT)
+                    .setEventData(responseEventData)
+                    .build();
+            extensionApi.dispatch(responseEvent);
+        }
     }
 
     void dispatchLastKnownLocation(final double latitude, final double longitude, final Event event) {
         final Map<String, Object> responseEventData = new HashMap<>();
         responseEventData.put(PlacesConstants.EventDataKeys.Places.LAST_KNOWN_LATITUDE, latitude);
         responseEventData.put(PlacesConstants.EventDataKeys.Places.LAST_KNOWN_LONGITUDE, longitude);
-        Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchLastKnownLocation - Dispatching last known location event with latitude: %s and longitude: %s",
-                latitude, longitude);
-        final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETLASTKNOWNLOCATION, EventType.PLACES,
-                EventSource.RESPONSE_CONTENT)
-                .setEventData(responseEventData)
-                .inResponseToEvent(event)
-                .build();
-        extensionApi.dispatch(responseEvent);
+        if (event != null) {
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchLastKnownLocation - Dispatching last known location event for API callback with latitude: %s and longitude: %s",
+                    latitude, longitude);
+            final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETLASTKNOWNLOCATION, EventType.PLACES,
+                    EventSource.RESPONSE_CONTENT)
+                    .setEventData(responseEventData)
+                    .inResponseToEvent(event)
+                    .build();
+            extensionApi.dispatch(responseEvent);
+        } else {
+            Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "dispatchLastKnownLocation - Dispatching last known location event for other listeners with latitude: %s and longitude: %s",
+                    latitude, longitude);
+            final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETLASTKNOWNLOCATION, EventType.PLACES,
+                    EventSource.RESPONSE_CONTENT)
+                    .setEventData(responseEventData)
+                    .build();
+            extensionApi.dispatch(responseEvent);
+        }
+
     }
 }

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesExtension.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesExtension.java
@@ -190,7 +190,7 @@ public class PlacesExtension extends Extension {
 
         final List<PlacesPOI> userWithinPOIs = state.getUserWithInPOIs();
 
-        // dispatch userWithinPOIS for the awaiting one time listener
+        // dispatch userWithinPOIS for getUserWithinPOI API callback registered with awaiting one time listener.
         placesDispatcher.dispatchUserWithinPOIs(userWithinPOIs, event);
         // dispatch userWithinPOIS for all other listeners
         placesDispatcher.dispatchUserWithinPOIs(userWithinPOIs, null);
@@ -211,7 +211,7 @@ public class PlacesExtension extends Extension {
             return;
         }
 
-        // dispatch lastKnownLocation for all other listeners
+        // dispatch lastKnownLocation for the getLastKnownLocation API callback waiting with registered onetime listener
         placesDispatcher.dispatchLastKnownLocation(location.getLatitude(), location.getLongitude(),
                 event);
         // dispatch lastKnownLocation for all other listeners
@@ -328,7 +328,7 @@ public class PlacesExtension extends Extension {
             // update the places shared state
             extensionApi.createSharedState(state.getPlacesSharedState(), event);
 
-            // dispatch nearbyPOI list to the awaiting one-time listener
+            // dispatch nearbyPOI for the getNearbyPOI API callback waiting with registered onetime listener
             placesDispatcher.dispatchNearbyPlaces(response.getAllPOIs(), PlacesRequestError.OK,
                     event);
             // dispatch nearbyPOI list for other listeners

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesQueryService.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesQueryService.java
@@ -108,7 +108,7 @@ class PlacesQueryService {
                     return;
                 }
 
-                Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "Got Response : %s", serverResponse);
+                Log.debug(PlacesConstants.LOG_TAG, CLASS_NAME, "Received Places Query Response : %s", serverResponse);
                 final JSONObject responseJson = new JSONObject(serverResponse);
 
                 final JSONObject placesJson = responseJson.getJSONObject(PlacesConstants.QueryResponseJsonKeys.PLACES);

--- a/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesDispatcherTests.java
+++ b/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesDispatcherTests.java
@@ -67,12 +67,13 @@ public class PlacesDispatcherTests {
 	private ArgumentCaptor<Event> dispatchedEventCaptor = ArgumentCaptor.forClass(Event.class);
 
 	@Test
-	public void test_dispatchNearbyPlaces() throws Exception {
+	public void test_dispatchNearbyPlaces() {
 		List<PlacesPOI> pois = new ArrayList<>();
 		pois.add(new PlacesPOI("identifier", "name", 34.33, -121.55, 50, SAMPLE_LIBRARY, SAMPLE_WEIGHT, null));
 
 		// test
-		placesDispatcher.dispatchNearbyPlaces(pois, PlacesRequestError.OK, triggerEvent);
+		final Event triggeringEvent = triggerEvent;
+		placesDispatcher.dispatchNearbyPlaces(pois, PlacesRequestError.OK, triggeringEvent);
 
 		// verify
 		verify(extensionApi).dispatch(dispatchedEventCaptor.capture());
@@ -86,16 +87,41 @@ public class PlacesDispatcherTests {
 					   PlacesTestConstants.EventDataKeys.Places.NEAR_BY_PLACES_LIST));
 		assertEquals(PlacesRequestError.OK.getValue(), (int)dispatchedEvent.getEventData().get(PlacesTestConstants.EventDataKeys.Places.RESULT_STATUS));
 		assertEquals(2, dispatchedEvent.getEventData().size());
+		assertEquals(triggeringEvent.getUniqueIdentifier(), dispatchedEvent.getResponseID());
 	}
 
 	@Test
-	public void test_dispatchUserWithinPOIs() throws Exception {
+	public void test_dispatchNearbyPlaces_withNullEvent() {
+		List<PlacesPOI> pois = new ArrayList<>();
+		pois.add(new PlacesPOI("identifier", "name", 34.33, -121.55, 50, SAMPLE_LIBRARY, SAMPLE_WEIGHT, null));
+
+		// test
+		placesDispatcher.dispatchNearbyPlaces(pois, PlacesRequestError.OK, null);
+
+		// verify
+		verify(extensionApi).dispatch(dispatchedEventCaptor.capture());
+		Event dispatchedEvent = dispatchedEventCaptor.getValue();
+
+		// verify dispatchedEvent
+		assertEquals(PlacesTestConstants.EventName.RESPONSE_GETNEARBYPLACES, dispatchedEvent.getName());
+		assertEquals(EventType.PLACES, dispatchedEvent.getType());
+		assertEquals(EventSource.RESPONSE_CONTENT, dispatchedEvent.getSource());
+		assertTrue(dispatchedEvent.getEventData().containsKey(
+				PlacesTestConstants.EventDataKeys.Places.NEAR_BY_PLACES_LIST));
+		assertEquals(PlacesRequestError.OK.getValue(), (int)dispatchedEvent.getEventData().get(PlacesTestConstants.EventDataKeys.Places.RESULT_STATUS));
+		assertEquals(2, dispatchedEvent.getEventData().size());
+		assertNull(dispatchedEvent.getResponseID());
+	}
+
+	@Test
+	public void test_dispatchUserWithinPOIs() {
 		List<PlacesPOI> pois = new ArrayList<PlacesPOI>();
 		pois.add(new PlacesPOI("identifier", "name", 34.33, -121.55, 50, SAMPLE_LIBRARY, SAMPLE_WEIGHT, null));
 		pois.add(new PlacesPOI("identifier2", "name", 34.33, -121.55, 50, SAMPLE_LIBRARY, SAMPLE_WEIGHT, null));
 
 		// test
-		placesDispatcher.dispatchUserWithinPOIs(pois, triggerEvent);
+		final Event triggeringEvent = triggerEvent;
+		placesDispatcher.dispatchUserWithinPOIs(pois, triggeringEvent);
 
 		// verify
 		verify(extensionApi).dispatch(dispatchedEventCaptor.capture());
@@ -110,6 +136,32 @@ public class PlacesDispatcherTests {
 					   PlacesTestConstants.EventDataKeys.Places.USER_WITHIN_POIS));
 		assertEquals(1, eventData.size());
 		assertEquals(2, ((Collection<?>) eventData.get(PlacesTestConstants.EventDataKeys.Places.USER_WITHIN_POIS)).size());
+		assertEquals(triggeringEvent.getUniqueIdentifier(), dispatchedEvent.getResponseID());
+	}
+
+	@Test
+	public void test_dispatchUserWithinPOIs_withNullEvent() {
+		List<PlacesPOI> pois = new ArrayList<PlacesPOI>();
+		pois.add(new PlacesPOI("identifier", "name", 34.33, -121.55, 50, SAMPLE_LIBRARY, SAMPLE_WEIGHT, null));
+		pois.add(new PlacesPOI("identifier2", "name", 34.33, -121.55, 50, SAMPLE_LIBRARY, SAMPLE_WEIGHT, null));
+
+		// test
+		placesDispatcher.dispatchUserWithinPOIs(pois, null);
+
+		// verify
+		verify(extensionApi).dispatch(dispatchedEventCaptor.capture());
+		Event dispatchedEvent = dispatchedEventCaptor.getValue();
+
+		// verify dispatchedEvent
+		assertEquals(PlacesTestConstants.EventName.RESPONSE_GETUSERWITHINPLACES, dispatchedEvent.getName());
+		assertEquals(EventType.PLACES, dispatchedEvent.getType());
+		assertEquals(EventSource.RESPONSE_CONTENT, dispatchedEvent.getSource());
+		Map<String, Object> eventData = dispatchedEvent.getEventData();
+		assertTrue(eventData.containsKey(
+				PlacesTestConstants.EventDataKeys.Places.USER_WITHIN_POIS));
+		assertEquals(1, eventData.size());
+		assertEquals(2, ((Collection<?>) eventData.get(PlacesTestConstants.EventDataKeys.Places.USER_WITHIN_POIS)).size());
+		assertNull(dispatchedEvent.getResponseID());
 	}
 
 	@Test
@@ -155,7 +207,8 @@ public class PlacesDispatcherTests {
 	@Test
 	public void test_dispatchLastKnownLocation() {
 		// test
-		placesDispatcher.dispatchLastKnownLocation(31.33, -121.33, triggerEvent);
+		final Event triggeringEvent = triggerEvent;
+		placesDispatcher.dispatchLastKnownLocation(31.33, -121.33, triggeringEvent);
 
 		// verify
 		verify(extensionApi).dispatch(dispatchedEventCaptor.capture());
@@ -170,6 +223,28 @@ public class PlacesDispatcherTests {
 		// verify location details
 		assertEquals(31.33,(double) dispatchedEvent.getEventData().get(PlacesTestConstants.EventDataKeys.Places.LAST_KNOWN_LATITUDE), 0);
 		assertEquals(-121.33, (double) dispatchedEvent.getEventData().get(PlacesTestConstants.EventDataKeys.Places.LAST_KNOWN_LONGITUDE), 0);
+		assertEquals(triggeringEvent.getUniqueIdentifier(), dispatchedEvent.getResponseID());
+	}
+
+	@Test
+	public void test_dispatchLastKnownLocation_withNullEvent() {
+		// test
+		placesDispatcher.dispatchLastKnownLocation(31.33, -121.33, null);
+
+		// verify
+		verify(extensionApi).dispatch(dispatchedEventCaptor.capture());
+		Event dispatchedEvent = dispatchedEventCaptor.getValue();
+
+		// verify event details
+		assertEquals(PlacesTestConstants.EventName.RESPONSE_GETLASTKNOWNLOCATION, dispatchedEvent.getName());
+		assertEquals(EventType.PLACES, dispatchedEvent.getType());
+		assertEquals(EventSource.RESPONSE_CONTENT, dispatchedEvent.getSource());
+		assertEquals(2, dispatchedEvent.getEventData().size());
+
+		// verify location details
+		assertEquals(31.33,(double) dispatchedEvent.getEventData().get(PlacesTestConstants.EventDataKeys.Places.LAST_KNOWN_LATITUDE), 0);
+		assertEquals(-121.33, (double) dispatchedEvent.getEventData().get(PlacesTestConstants.EventDataKeys.Places.LAST_KNOWN_LONGITUDE), 0);
+		assertNull(dispatchedEvent.getResponseID());
 	}
 
 }


### PR DESCRIPTION
Setting `inResponseToEvent` to null while building an event will create an exception when this event is dispatched. 

```
final Event responseEvent = new Event.Builder(PlacesConstants.EventName.RESPONSE_GETNEARBYPLACES, 
                    EventType.PLACES,
                    EventSource.RESPONSE_CONTENT)
                    .setEventData(responseEventData)
                    .inResponseToEvent(event)
                    .build();
            extensionApi.dispatch(responseEvent);
```
- This PR contains fix and some tests for this bug
- Fix flaky functional test