### PR TITLE
AEP integration with Places

### DIFF
--- a/code/places/build.gradle
+++ b/code/places/build.gradle
@@ -61,7 +61,8 @@ android {
 dependencies {
     //noinspection GradleDependency
     implementation 'androidx.annotation:annotation:1.0.0'
-    implementation 'com.adobe.marketing.mobile:core:2.0.0'
+    implementation 'com.adobe.marketing.mobile:core:2.1.0'
+    implementation "com.adobe.marketing.mobile:edge:2.0.0"
     implementation 'com.google.android.gms:play-services-location:21.0.1'
 
     testImplementation 'junit:junit:4.13.2'

--- a/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/MonitorExtension.kt
+++ b/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/MonitorExtension.kt
@@ -28,12 +28,14 @@ class MonitorExtension : Extension {
         var capturedNearByPOIEvent: Event? = null
         var capturedLastKnownLocationEvent: Event? = null
         var capturedUserWithinPlacesEvent: Event? = null
+        var latestEdgeEvent: Event? = null
         private var configurationMonitor: ConfigurationMonitor? = null
         var waitForNearByPOIExternalEvent = CountDownLatch(1)
         var waitForLastKnownLocationExternalEvent = CountDownLatch(1)
         var waitForUserWithInPOIExternalEvent = CountDownLatch(1)
         var waitForSharedStateToSet = CountDownLatch(1)
         var waitForRegionEvent = CountDownLatch(1)
+        var waitForExperienceEvent = CountDownLatch(1)
         internal fun configurationAwareness(callback: ConfigurationMonitor) {
             configurationMonitor = callback
         }
@@ -44,11 +46,13 @@ class MonitorExtension : Extension {
             capturedNearByPOIEvent = null
             capturedLastKnownLocationEvent = null
             capturedUserWithinPlacesEvent = null
+            latestEdgeEvent = null
             waitForNearByPOIExternalEvent = CountDownLatch(1)
             waitForLastKnownLocationExternalEvent = CountDownLatch(1)
             waitForUserWithInPOIExternalEvent = CountDownLatch(1)
             waitForSharedStateToSet = CountDownLatch(1)
             waitForRegionEvent = CountDownLatch(1)
+            waitForExperienceEvent = CountDownLatch(1)
         }
     }
 
@@ -76,6 +80,9 @@ class MonitorExtension : Extension {
         }
         api.registerEventListener(EventType.PLACES, EventSource.RESPONSE_CONTENT) {
             handlePlacesResponseContent(it)
+        }
+        api.registerEventListener(EventType.EDGE, EventSource.REQUEST_CONTENT) {
+            handleEdgeRequestContent(it)
         }
         api.registerEventListener(EventType.WILDCARD, EventSource.WILDCARD) { event ->
             val result = api.getSharedState(
@@ -125,6 +132,13 @@ class MonitorExtension : Extension {
         if(event.name == "responsegetuserwithinplaces") {
             capturedUserWithinPlacesEvent = event
             waitForUserWithInPOIExternalEvent.countDown()
+        }
+    }
+
+    fun handleEdgeRequestContent(event: Event) {
+        if(event.name == "Location Tracking Event") {
+            latestEdgeEvent = event
+            waitForExperienceEvent.countDown()
         }
     }
 }

--- a/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/PlacesIntegrationTest.kt
+++ b/code/places/src/androidTest/java/com/adobe/marketing/mobile/places/PlacesIntegrationTest.kt
@@ -537,7 +537,7 @@ class PlacesIntegrationTest {
         // enter into a geofence
         Places.processGeofence(geofence, Geofence.GEOFENCE_TRANSITION_ENTER)
 
-        // wait
+        // wait for response process region event
         MonitorExtension.waitForSharedStateToSet.await(3, TimeUnit.SECONDS)
         MonitorExtension.waitForRegionEvent.await(3, TimeUnit.SECONDS)
 
@@ -549,6 +549,15 @@ class PlacesIntegrationTest {
         assertNotNull(MonitorExtension.latestRegionEvent)
         assertEquals("entry",getLastRegionEventType())
         assertEquals("Meridian & SanCarlos",getLastRegionEventPOIName())
+
+        // wait for experience event
+        assertTrue(MonitorExtension.waitForExperienceEvent.await(3, TimeUnit.SECONDS))
+
+        // verify the edge event dispatched
+        assertNotNull(MonitorExtension.latestEdgeEvent)
+        assertEquals("location.entry", getEdgeEventType())
+        assertEquals("Meridian & SanCarlos", getEdgeEventPOIName())
+        assertEquals("a5f6cd21-3acb-4c76-90d3-52bfea5aa1ad", getEdgeEventPoiEntriesId())
     }
 
 
@@ -603,6 +612,16 @@ class PlacesIntegrationTest {
         assertNotNull(MonitorExtension.latestRegionEvent)
         assertEquals("exit",getLastRegionEventType())
         assertEquals("Cityview Plaza",getLastRegionEventPOIName())
+
+
+        // wait for experience event
+        assertTrue(MonitorExtension.waitForExperienceEvent.await(3, TimeUnit.SECONDS))
+
+        // verify the edge event dispatched
+        assertNotNull(MonitorExtension.latestEdgeEvent)
+        assertEquals("location.exit", getEdgeEventType())
+        assertEquals("Cityview Plaza", getEdgeEventPOIName())
+        assertEquals("d74cb328-d2f3-4ea9-9af8-7dc8c3393280", getEdgeEventPoiExitsId())
     }
 
     //---------------------------------------------------------------------------------------------
@@ -612,7 +631,8 @@ class PlacesIntegrationTest {
     private fun setupConfiguration(libraries: List<String>? = listOf<String>("library1"),
                                    endpoint: String? = "placesendpoint",
                                    privacyStatus: String? = MobilePrivacyStatus.OPT_IN.value,
-                                   membershipTtl: Long? = 20) {
+                                   membershipTtl: Long? = 20,
+                                   datasetId: String = "1234") {
         val libraryConfig : MutableList<Map<String,String>> = ArrayList()
         if (libraries != null) {
             for (library in libraries) {
@@ -625,7 +645,8 @@ class PlacesIntegrationTest {
             PlacesConstants.EventDataKeys.Configuration.CONFIG_KEY_PLACES_ENDPOINT to endpoint,
             PlacesConstants.EventDataKeys.Configuration.CONFIG_KEY_PLACES_MEMBERSHIP_TTL to membershipTtl,
             PlacesConstants.EventDataKeys.Configuration.CONFIG_KEY_GLOBAL_PRIVACY to privacyStatus,
-            PlacesConstants.EventDataKeys.Configuration.CONFIG_KEY_PLACES_LIBRARIES to libraryConfig
+            PlacesConstants.EventDataKeys.Configuration.CONFIG_KEY_PLACES_LIBRARIES to libraryConfig,
+            PlacesConstants.EventDataKeys.Configuration.CONFIG_KEY_EXPERIENCE_EVENT_DATASET to datasetId
         ))
     }
 
@@ -666,11 +687,36 @@ class PlacesIntegrationTest {
         return MonitorExtension.latestRegionEvent?.eventData?.get("regioneventtype") as String?
     }
 
-    private fun getLastRegionEventPOIName() : String ? {
+    private fun getLastRegionEventPOIName() : String? {
         val triggeringRegion = MonitorExtension.latestRegionEvent?.eventData?.get("triggeringregion") as Map<*, *>?
         return triggeringRegion?.get("regionname") as String?
     }
 
+    private fun getEdgeEventType() : String? {
+        val xdm = MonitorExtension.latestEdgeEvent?.eventData?.get("xdm") as Map<*, *>?
+        return xdm?.get("eventType") as String?
+    }
+
+    private fun getEdgeEventPOIName() : String? {
+        val xdm = MonitorExtension.latestEdgeEvent?.eventData?.get("xdm") as Map<*, *>?
+        val poiDetail = ((xdm?.get("placeContext") as Map<*, *>?)
+            ?.get("POIinteraction") as Map<*, *>?)?.get("poiDetail") as Map<*, *>?
+        return poiDetail?.get("name") as String?
+    }
+
+    private fun getEdgeEventPoiEntriesId() : String? {
+        val xdm = MonitorExtension.latestEdgeEvent?.eventData?.get("xdm") as Map<*, *>?
+        val poiEntries = ((xdm?.get("placeContext") as Map<*, *>?)
+            ?.get("POIinteraction") as Map<*, *>?)?.get("poiEntries") as Map<*, *>?
+        return poiEntries?.get("id") as String?
+    }
+
+    private fun getEdgeEventPoiExitsId() : String? {
+        val xdm = MonitorExtension.latestEdgeEvent?.eventData?.get("xdm") as Map<*, *>?
+        val poiExits = ((xdm?.get("placeContext") as Map<*, *>?)
+            ?.get("POIinteraction") as Map<*, *>?)?.get("poiExits") as Map<*, *>?
+        return poiExits?.get("id") as String?
+    }
 }
 
 private fun configurationAwareness(callback: ConfigurationMonitor) {

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesConfiguration.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesConfiguration.java
@@ -27,6 +27,7 @@ class PlacesConfiguration {
 	private String endpoint;
 	private long membershipTtl;
 	private boolean isValid;
+	private String experienceEventDataset;
 
 	PlacesConfiguration(final Map<String, Object> configData) {
 		this();
@@ -80,6 +81,8 @@ class PlacesConfiguration {
 		membershipTtl = DataReader.optLong(configData, PlacesConstants.EventDataKeys.Configuration.CONFIG_KEY_PLACES_MEMBERSHIP_TTL,
 				PlacesConstants.DEFAULT_MEMBERSHIP_TTL);
 		isValid = true;
+
+		experienceEventDataset = DataReader.optString(configData, PlacesConstants.EventDataKeys.Configuration.CONFIG_KEY_EXPERIENCE_EVENT_DATASET, "");
 	}
 
 	String getLibrariesQueryString() {
@@ -103,6 +106,10 @@ class PlacesConfiguration {
 
 	long getMembershipTtl() {
 		return membershipTtl;
+	}
+
+	String getExperienceEventDataset() {
+		return experienceEventDataset;
 	}
 
 	// hiding the default constructor

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesConstants.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesConstants.java
@@ -97,6 +97,7 @@ final class PlacesConstants {
         static final String RESPONSE_PROCESSREGIONEVENT = "responseprocessregionevent";
         static final String RESPONSE_GETUSERWITHINPLACES = "responsegetuserwithinplaces";
         static final String RESPONSE_GETLASTKNOWNLOCATION = "responsegetlastknownlocation";
+        static final String LOCATION_TRACKING = "Location Tracking Event";
 
         private EventName() {
         }
@@ -157,10 +158,80 @@ final class PlacesConstants {
             static final String CONFIG_KEY_LIBRARY_ID = "id";
             static final String CONFIG_KEY_PLACES_ENDPOINT = "places.endpoint";
             static final String CONFIG_KEY_PLACES_MEMBERSHIP_TTL = "places.membershipttl";
+            static final String CONFIG_KEY_EXPERIENCE_EVENT_DATASET = "messaging.eventDataset";
 
             private Configuration() {
             }
         }
 
+    }
+
+    static final class XDM {
+
+        private XDM() {
+
+        }
+
+        static final class Key {
+
+            private Key() {
+
+            }
+
+            static final String EVENT_TYPE = "eventType";
+            static final String XDM = "xdm";
+
+            static final String META = "meta";
+            static final String COLLECT = "collect";
+            static final String DATASET_ID = "datasetId";
+
+            static final String PLACE_CONTEXT = "placeContext";
+            static final String POI_INTERACTION = "POIinteraction";
+            static final String POI_DETAIL = "poiDetail";
+            static final String GEO_INTERACTION_DETAILS = "geoInteractionDetails";
+            static final String GEO_SHAPE = "geoShape";
+            static final String SCHEMA = "_schema";
+            static final String GEO = "geo";
+            static final String CIRCLE = "circle";
+            static final String COORDINATES = "coordinates";
+
+            static final String POI_ID = "poiID";
+            static final String NAME = "name";
+            static final String LATITUDE = "latitude";
+            static final String LONGITUDE = "longitude";
+            static final String RADIUS = "radius";
+
+            static final String COUNTRY_CODE = "countryCode";
+            static final String CITY = "city";
+            static final String POSTAL_CODE = "postalCode";
+            static final String STATE_PROVINCE = "stateProvince";
+            static final String CATEGORY = "category";
+
+            static final String METADATA = "metadata";
+            static final String LIST = "list";
+            static final String KEY = "key";
+            static final String VALUE = "value";
+
+            static final String POIENTRIES = "poiEntries";
+            static final String POIEXITS = "poiExits";
+            static final String ID = "id";
+        }
+
+        static final class Location {
+
+            private Location() {
+
+            }
+
+            static final class EventType {
+
+                private EventType() {
+
+                }
+
+                static final String ENTRY = "location.entry";
+                static final String EXIT = "location.exit";
+            }
+        }
     }
 }

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesExtension.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesExtension.java
@@ -359,6 +359,9 @@ public class PlacesExtension extends Extension {
 
         // dispatch the processed region event
         placesDispatcher.dispatchRegionEvent(regionEvent);
+
+        // dispatch experience event to Edge
+        placesDispatcher.dispatchExperienceEventToEdge(regionEvent, placesConfig);
     }
 
 

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesRegion.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesRegion.java
@@ -47,9 +47,22 @@ final class PlacesRegion extends PlacesPOI {
         this.timestamp = timestamp;
     }
 
+    PlacesPOI getPoi() {
+        return poi;
+    }
 
     String getPlaceEventType() {
         return placeEventType;
+    }
+
+    String getExperienceEventType() {
+        switch (placeEventType) {
+            case PLACE_EVENT_ENTRY:
+                return PlacesConstants.XDM.Location.EventType.ENTRY;
+            case PLACE_EVENT_EXIT:
+                return PlacesConstants.XDM.Location.EventType.EXIT;
+        }
+        return "";
     }
 }
 

--- a/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesState.java
+++ b/code/places/src/main/java/com/adobe/marketing/mobile/places/PlacesState.java
@@ -171,7 +171,7 @@ class PlacesState {
             persistPOIs();
             return new PlacesRegion(matchedPOI, PlacesRegion.PLACE_EVENT_EXIT, event.getTimestamp());
         } else {
-            Log.warning(PlacesConstants.LOG_TAG, "Unknown region type : %s, Ignoring to process geofence event", regionType);
+            Log.warning(PlacesConstants.LOG_TAG, CLASS_NAME, "Unknown region type : %s, Ignoring to process geofence event", regionType);
             return null;
         }
     }

--- a/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesConfigurationTests.java
+++ b/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesConfigurationTests.java
@@ -149,6 +149,30 @@ public class PlacesConfigurationTests {
         assertEquals(PlacesTestConstants.DEFAULT_MEMBERSHIP_TTL, configuration.getMembershipTtl());
     }
 
+    @Test
+    public void testConfiguration_WhenExperienceEventDatasetIsPresent() {
+        // test
+        final Map<String, Object> configData = createConfigData(2, SAMPLE_ENDPOINT, SAMPLE_MEMBERSHIP_TTL);
+        configData.put(PlacesTestConstants.EventDataKeys.Configuration.CONFIG_KEY_EXPERIENCE_EVENT_DATASET, "12345");
+
+        final PlacesConfiguration configuration = new PlacesConfiguration(configData);
+
+        // verify
+        assert(configuration.isValid());
+        assertEquals("12345", configuration.getExperienceEventDataset());
+    }
+
+    @Test
+    public void testConfiguration_WhenExperienceEventDatasetIsNotPresent() {
+        // test
+        final Map<String, Object> configData = createConfigData(2, SAMPLE_ENDPOINT, SAMPLE_MEMBERSHIP_TTL);
+
+        final PlacesConfiguration configuration = new PlacesConfiguration(configData);
+
+        // verify
+        assert(configuration.isValid());
+        assertEquals("", configuration.getExperienceEventDataset());
+    }
 
     @Test
     public void testConfiguration_Happy() {

--- a/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesExtensionTests.java
+++ b/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesExtensionTests.java
@@ -306,6 +306,9 @@ public class PlacesExtensionTests {
 
 		// verify the dispatched event
 		verify(placesDispatcher).dispatchRegionEvent(eq(region));
+
+		// verify the dispatched edge event
+		verify(placesDispatcher).dispatchExperienceEventToEdge(eq(region), any());
 	}
 
 	// ========================================================================================

--- a/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesStateTests.java
+++ b/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesStateTests.java
@@ -347,6 +347,7 @@ public class PlacesStateTests {
         assertNotNull(returnedRegion);
         assertEquals("highWeightPOI", returnedRegion.getIdentifier());
         assertEquals(PlacesRegion.PLACE_EVENT_ENTRY, returnedRegion.getPlaceEventType());
+        assertEquals(PlacesTestConstants.XDM.Location.EventType.ENTRY, returnedRegion.getExperienceEventType());
 
         // verify memory variables
         assertEquals("highWeightPOI", placesState.currentPOI.getIdentifier());
@@ -391,6 +392,7 @@ public class PlacesStateTests {
         assertNotNull(returnedRegion);
         assertEquals("lowWeightPOI", returnedRegion.getIdentifier());
         assertEquals(PlacesRegion.PLACE_EVENT_ENTRY, returnedRegion.getPlaceEventType());
+        assertEquals(PlacesTestConstants.XDM.Location.EventType.ENTRY, returnedRegion.getExperienceEventType());
 
         // verify memory variables
         assertEquals("highWeightPOI", placesState.currentPOI.getIdentifier());
@@ -435,6 +437,7 @@ public class PlacesStateTests {
         assertNotNull(returnedRegion);
         assertEquals("poi1", returnedRegion.getIdentifier());
         assertEquals(PlacesRegion.PLACE_EVENT_EXIT, returnedRegion.getPlaceEventType());
+        assertEquals(PlacesTestConstants.XDM.Location.EventType.EXIT, returnedRegion.getExperienceEventType());
 
         // verify memory variables
         assertNull(placesState.currentPOI);
@@ -524,6 +527,7 @@ public class PlacesStateTests {
         assertNotNull(returnedRegion);
         assertEquals("poi1", returnedRegion.getIdentifier());
         assertEquals(PlacesRegion.PLACE_EVENT_EXIT, returnedRegion.getPlaceEventType());
+        assertEquals(PlacesTestConstants.XDM.Location.EventType.EXIT, returnedRegion.getExperienceEventType());
 
         // verify memory variables
         assertNull(placesState.currentPOI);
@@ -568,6 +572,7 @@ public class PlacesStateTests {
         assertNotNull(returnedRegion);
         assertEquals("mediumWeight", returnedRegion.getIdentifier());
         assertEquals(PlacesRegion.PLACE_EVENT_EXIT, returnedRegion.getPlaceEventType());
+        assertEquals(PlacesTestConstants.XDM.Location.EventType.EXIT, returnedRegion.getExperienceEventType());
 
         // verify memory variables
         assertEquals("highWeight", placesState.currentPOI.getIdentifier());
@@ -585,6 +590,7 @@ public class PlacesStateTests {
         assertNotNull(returnedRegion2);
         assertEquals("highWeight", returnedRegion2.getIdentifier());
         assertEquals(PlacesRegion.PLACE_EVENT_EXIT, returnedRegion2.getPlaceEventType());
+        assertEquals(PlacesTestConstants.XDM.Location.EventType.EXIT, returnedRegion.getExperienceEventType());
 
         // verify memory variables
         assertEquals("lowWeight", placesState.currentPOI.getIdentifier());

--- a/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesTestConstants.java
+++ b/code/places/src/test/java/com/adobe/marketing/mobile/places/PlacesTestConstants.java
@@ -163,9 +163,80 @@ final class PlacesTestConstants {
             static final String CONFIG_KEY_LIBRARY_ID = "id";
             static final String CONFIG_KEY_PLACES_ENDPOINT = "places.endpoint";
             static final String CONFIG_KEY_PLACES_MEMBERSHIP_TTL = "places.membershipttl";
+            static final String CONFIG_KEY_EXPERIENCE_EVENT_DATASET = "messaging.eventDataset";
+
             private Configuration() {
             }
         }
 
+    }
+
+    static final class XDM {
+
+        private XDM() {
+
+        }
+
+        static final class Key {
+
+            private Key() {
+
+            }
+
+            static final String EVENT_TYPE = "eventType";
+            static final String XDM = "xdm";
+
+            static final String META = "meta";
+            static final String COLLECT = "collect";
+            static final String DATASET_ID = "datasetId";
+
+            static final String PLACE_CONTEXT = "placeContext";
+            static final String POI_INTERACTION = "POIinteraction";
+            static final String POI_DETAIL = "poiDetail";
+            static final String GEO_INTERACTION_DETAILS = "geoInteractionDetails";
+            static final String GEO_SHAPE = "geoShape";
+            static final String SCHEMA = "_schema";
+            static final String GEO = "geo";
+            static final String CIRCLE = "circle";
+            static final String COORDINATES = "coordinates";
+
+            static final String POI_ID = "poiID";
+            static final String NAME = "name";
+            static final String LATITUDE = "latitude";
+            static final String LONGITUDE = "longitude";
+            static final String RADIUS = "radius";
+
+            static final String COUNTRY_CODE = "countryCode";
+            static final String CITY = "city";
+            static final String POSTAL_CODE = "postalCode";
+            static final String STATE_PROVINCE = "stateProvince";
+            static final String CATEGORY = "category";
+
+            static final String METADATA = "metadata";
+            static final String LIST = "list";
+            static final String KEY = "key";
+            static final String VALUE = "value";
+
+            static final String POIENTRIES = "poiEntries";
+            static final String POIEXITS = "poiExits";
+            static final String ID = "id";
+        }
+
+        static final class Location {
+
+            private Location() {
+
+            }
+
+            static final class EventType {
+
+                private EventType() {
+
+                }
+
+                static final String ENTRY = "location.entry";
+                static final String EXIT = "location.exit";
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Added logic to dispatch Edge Request Content Event every time a location entry or exit occurs. The dataset id used for the event is the `AJO Push Tracking Experience Event Dataset` from the AEP Messaging extension configuration. The XDM field group used to populate the Places data is the `PlacesContext` field group which is already added to this dataset by default.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Motivation behind this change is to be able to use the newly added experience events as triggers for AJO Campaigns and Journeys.

## How Has This Been Tested?

Added unit and integration tests to cover the changes. Also tested E2E with AJO Campaigns and Journeys to ensure the triggers are working as expected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
